### PR TITLE
Add failing Tests for #92

### DIFF
--- a/packages/react-async/src/useAsync.spec.js
+++ b/packages/react-async/src/useAsync.spec.js
@@ -250,4 +250,54 @@ describe("useFetch", () => {
       expect.objectContaining({ preventDefault: expect.any(Function) })
     )
   })
+
+  test("defer=true allows using the promise", () => {
+    let check = 0
+    const component = (
+      <Fetch input="/test" options={{ defer: true }}>
+        {({ run, promise }) => (
+          <button
+            onClick={() => {
+              run()
+              promise
+                .then(() => {
+                  return (check = 1)
+                })
+                .catch(() => {})
+            }}
+          >
+            run
+          </button>
+        )}
+      </Fetch>
+    )
+    const { getByText } = render(component)
+    fireEvent.click(getByText("run"))
+    expect(check).toEqual(1)
+  })
+
+  test("defer=false allows using the promise", () => {
+    let check = 0
+    const component = (
+      <Fetch input="/test" options={{ defer: false }}>
+        {({ run, promise }) => (
+          <button
+            onClick={() => {
+              run()
+              promise
+                .then(() => {
+                  return (check = 1)
+                })
+                .catch(() => {})
+            }}
+          >
+            run
+          </button>
+        )}
+      </Fetch>
+    )
+    const { getByText } = render(component)
+    fireEvent.click(getByText("run"))
+    expect(check).toEqual(1)
+  })
 })

--- a/packages/react-async/src/useAsync.spec.js
+++ b/packages/react-async/src/useAsync.spec.js
@@ -280,10 +280,9 @@ describe("useFetch", () => {
     let check = 0
     const component = (
       <Fetch input="/test" options={{ defer: false }}>
-        {({ run, promise }) => (
+        {({ promise }) => (
           <button
             onClick={() => {
-              run()
               promise
                 .then(() => {
                   return (check = 1)


### PR DESCRIPTION
These are the tests that demonstrate that one can not use the promise with `useFetch`.
