### PR TITLE
remove non implemented types IfLoading and IfResolved

### DIFF
--- a/packages/react-async/src/index.d.ts
+++ b/packages/react-async/src/index.d.ts
@@ -187,17 +187,7 @@ export function IfPending<T>(props: {
   initial?: boolean
   state: AsyncState<T>
 }): JSX.Element
-export function IfLoading<T>(props: {
-  children?: PendingChildren<T>
-  initial?: boolean
-  state: AsyncState<T>
-}): JSX.Element
 export function IfFulfilled<T>(props: {
-  children?: FulfilledChildren<T>
-  persist?: boolean
-  state: AsyncState<T>
-}): JSX.Element
-export function IfResolved<T>(props: {
   children?: FulfilledChildren<T>
   persist?: boolean
   state: AsyncState<T>


### PR DESCRIPTION
This is something I noticed while working with `react-async`, but it wasn't until we worked on #105 that I realised what was going on:
There are two types `IfLoading` and `IfResolved`, that are declared, but never implemented. This leads to bugs, where one imports one of these types and then the build fails.
Since these types are identical to `IfPending` und `IfFulfilled` respectively they can simply be deleted.