### PR TITLE
Replace synthetic default imports with star import in ts definition

### DIFF
--- a/packages/react-async/src/index.d.ts
+++ b/packages/react-async/src/index.d.ts
@@ -1,4 +1,4 @@
-import React from "react"
+import * as React from "react"
 
 export type AsyncChildren<T> = ((state: AsyncState<T>) => React.ReactNode) | React.ReactNode
 export type InitialChildren<T> = ((state: AsyncInitial<T>) => React.ReactNode) | React.ReactNode


### PR DESCRIPTION
# Description

Fix for #109.

It's not a good idea to use **`allowSyntheticDefaultImports`** feature in a typescript module definition yet because:
1. React does not provide **default export** to encourage module bundler's tree shaking feature.
    https://github.com/facebook/react/issues/11503
2. Typescript compiler's **`allowSyntheticDefaultImports`** (or **`esModuleInterop`**) feature is turned off by default. So using it forces people to use the same compiler option.
    https://github.com/microsoft/TypeScript/issues/10895

## Breaking changes

> Does this include any (potentially) breaking API changes?

No.

# Checklist

Make sure you check all the boxes. You can omit items that are not applicable.

- [x] Updated the TypeScript type definitions
