### PR TITLE
Make sure useFetch rejects with an Error type.

### DIFF
--- a/packages/react-async/src/index.d.ts
+++ b/packages/react-async/src/index.d.ts
@@ -234,4 +234,8 @@ type FetchRun<T> = {
   run(): void
 }
 
+export interface FetchError extends Error {
+  response: Response
+}
+
 export default Async

--- a/packages/react-async/src/index.d.ts
+++ b/packages/react-async/src/index.d.ts
@@ -234,7 +234,7 @@ type FetchRun<T> = {
   run(): void
 }
 
-export interface FetchError extends Error {
+export class FetchError extends Error {
   response: Response
 }
 

--- a/packages/react-async/src/index.js
+++ b/packages/react-async/src/index.js
@@ -1,6 +1,6 @@
 import Async from "./Async"
 export { default as Async, createInstance } from "./Async"
-export { default as useAsync, useFetch } from "./useAsync"
+export { default as useAsync, useFetch, FetchError } from "./useAsync"
 export default Async
 export { statusTypes } from "./status"
 export { default as globalScope } from "./globalScope"

--- a/packages/react-async/src/useAsync.js
+++ b/packages/react-async/src/useAsync.js
@@ -154,8 +154,15 @@ const useAsync = (arg1, arg2) => {
   )
 }
 
+export class FetchError extends Error {
+  constructor(response) {
+    super(response.statusText)
+    this.response = response
+  }
+}
+
 const parseResponse = (accept, json) => res => {
-  if (!res.ok) return Promise.reject(res)
+  if (!res.ok) return Promise.reject(new FetchError(res))
   if (typeof json === "boolean") return json ? res.json() : res
   return accept === "application/json" ? res.json() : res
 }

--- a/packages/react-async/src/useAsync.js
+++ b/packages/react-async/src/useAsync.js
@@ -156,7 +156,7 @@ const useAsync = (arg1, arg2) => {
 
 export class FetchError extends Error {
   constructor(response) {
-    super(response.statusText)
+    super(`${response.status} ${response.statusText}`)
     this.response = response
   }
 }

--- a/packages/react-async/src/useAsync.spec.js
+++ b/packages/react-async/src/useAsync.spec.js
@@ -252,7 +252,7 @@ describe("useFetch", () => {
   })
 
   test("throws a FetchError for failed requests", async () => {
-    const errorResponse = { ok: false, statusText: "Bad Request", json }
+    const errorResponse = { ok: false, status: 400, statusText: "Bad Request", json }
     globalScope.fetch.mockResolvedValue(errorResponse)
     const onResolve = jest.fn()
     const onReject = jest.fn()
@@ -263,7 +263,7 @@ describe("useFetch", () => {
     expect(onReject).toHaveBeenCalled()
     let [err] = onReject.mock.calls[0]
     expect(err).toBeInstanceOf(FetchError)
-    expect(err.message).toEqual("Bad Request")
+    expect(err.message).toEqual("400 Bad Request")
     expect(err.response).toBe(errorResponse)
   })
 })


### PR DESCRIPTION
# Description

Failed http responses in `useFetch` now reject with a FetchError,
with the underlying Response object available as error.response.

Previously, a non-ok http response would reject with the response
object directly. It's better for rejections to be of type Error
so that the full stack trace information is available; plus, the
TypeScript type definition assumes that the error object is always
instanceof Error.

Fixes #113.

## Breaking changes

The `error` property of the state object returned by `useFetch`
is no longer a Response object. If you need the response object,
replace references to `state.error` with `state.error.response`.

# Checklist

- [x] Added / updated the unit tests
- [ ] Added / updated the documentation
- [x] Updated the TypeScript type definitions
