### PR TITLE
Move prop-types into dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,6 +34,9 @@
     "bump": "lerna version -m 'Bump' --no-git-tag-version --no-push",
     "postbump": "yarn build:packages"
   },
+  "dependencies": {
+    "prop-types": "15.7.2"
+  },
   "devDependencies": {
     "@babel/core": "7.6.0",
     "@babel/plugin-proposal-object-rest-spread": "7.5.5",
@@ -64,7 +67,6 @@
     "now": "16.2.0",
     "npm-run-all": "4.1.5",
     "prettier": "1.18.2",
-    "prop-types": "15.7.2",
     "react": "16.9.0",
     "react-async": "^8.0.0-alpha.0",
     "react-dom": "16.9.0",


### PR DESCRIPTION
# Description

Package managers such as PNPM will not install the `prop-types` package if not explicitly defined in "dependecies"

## Breaking changes

No
