### PR TITLE
Add CodeFund sponsorship message to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,11 @@
 <p align="center">
   <a href="https://react-async.dev"><img src="https://raw.githubusercontent.com/async-library/react-async/HEAD/react-async.png" width="520" alt="React Async" /></a><br/>
   Handle promises with ease.
+  <br/>
+  <br/>
+  <a href="https://codefund.io/properties/458/visit-sponsor">
+    <img src="https://codefund.io/properties/458/sponsor" />
+  </a>
 </p>
 <br/>
 


### PR DESCRIPTION
[CodeFund](https://codefund.io) provides ethical sponsorships to open source maintainers. This PR will place the "Sponsored by" image at the top of the README. The sponsoring companies are not paying per click nor impression. They are paying the maintainer(s) on a per-month basis to be the primary sponsor of this project.
