### PR TITLE
Allow overriding the 'resource' argument of 'fetch' when invoking 'run'.

### DIFF
--- a/README.md
+++ b/README.md
@@ -695,13 +695,20 @@ throw an exception and crash if the promise rejects.
 
 Runs the `deferFn`, passing any arguments provided as an array.
 
-When used with `useFetch`, `run` has a different signature:
+When used with `useFetch`, `run` has several overloaded signatures:
+
+> `function(resource: String | Resource, init: Object | (init: Object) => Object): void`
 
 > `function(init: Object | (init: Object) => Object): void`
 
-This runs the `fetch` request using the provided `init`. If it's an object it will be spread over the default `init`
-(`useFetch`'s 2nd argument). If it's a function it will be invoked with the default `init` and should return a new
-`init` object. This way you can either extend or override the value of `init`, for example to set request headers.
+> `function(event: SyntheticEvent | Event): void`
+
+> `function(): void`
+
+This way you can run the `fetch` request using the provided `resource` and `init`. `resource` can be omitted. If `init`
+is an object it will be spread over the default `init` (`useFetch`'s 2nd argument). If it's a function it will be
+invoked with the default `init` and should return a new `init` object. This way you can either extend or override the
+value of `init`, for example to set request headers.
 
 #### `reload`
 

--- a/packages/react-async/src/index.d.ts
+++ b/packages/react-async/src/index.d.ts
@@ -227,6 +227,8 @@ type AsyncInitialWithout<K extends keyof AsyncInitial<T>, T> =
   | Omit<AsyncRejected<T>, K>
 
 type FetchRun<T> = {
+  run(overrideResource: RequestInfo, overrideInit: (init: RequestInit) => RequestInit): void
+  run(overrideResource: RequestInfo, overrideInit: Partial<RequestInit>): void
   run(overrideInit: (init: RequestInit) => RequestInit): void
   run(overrideInit: Partial<RequestInit>): void
   run(ignoredEvent: React.SyntheticEvent): void

--- a/packages/react-async/src/useAsync.spec.js
+++ b/packages/react-async/src/useAsync.spec.js
@@ -203,11 +203,11 @@ describe("useFetch", () => {
     expect(json).toHaveBeenCalled()
   })
 
-  test("calling `run` with a method argument allows to override `init` parameters", () => {
+  test("calling `run` with a callback as argument allows to override `init` parameters", () => {
     const component = (
-      <Fetch input="/test" init={{ method: "POST" }}>
+      <Fetch input="/test" init={{ method: "POST", body: '{"name":"foo"}' }}>
         {({ run }) => (
-          <button onClick={() => run(init => ({ ...init, body: '{"name":"test"}' }))}>run</button>
+          <button onClick={() => run(init => ({ ...init, body: '{"name":"bar"}' }))}>run</button>
         )}
       </Fetch>
     )
@@ -216,14 +216,14 @@ describe("useFetch", () => {
     fireEvent.click(getByText("run"))
     expect(globalScope.fetch).toHaveBeenCalledWith(
       "/test",
-      expect.objectContaining({ method: "POST", signal: abortCtrl.signal, body: '{"name":"test"}' })
+      expect.objectContaining({ method: "POST", signal: abortCtrl.signal, body: '{"name":"bar"}' })
     )
   })
 
   test("calling `run` with an object as argument allows to override `init` parameters", () => {
     const component = (
-      <Fetch input="/test" init={{ method: "POST" }}>
-        {({ run }) => <button onClick={() => run({ body: '{"name":"test"}' })}>run</button>}
+      <Fetch input="/test" init={{ method: "POST", body: '{"name":"foo"}' }}>
+        {({ run }) => <button onClick={() => run({ body: '{"name":"bar"}' })}>run</button>}
       </Fetch>
     )
     const { getByText } = render(component)
@@ -231,7 +231,41 @@ describe("useFetch", () => {
     fireEvent.click(getByText("run"))
     expect(globalScope.fetch).toHaveBeenCalledWith(
       "/test",
-      expect.objectContaining({ method: "POST", signal: abortCtrl.signal, body: '{"name":"test"}' })
+      expect.objectContaining({ method: "POST", signal: abortCtrl.signal, body: '{"name":"bar"}' })
+    )
+  })
+
+  test("calling `run` with a url allows to override fetch's `resource` parameter", () => {
+    const component = (
+      <Fetch input="/foo" options={{ defer: true }}>
+        {({ run }) => <button onClick={() => run("/bar")}>run</button>}
+      </Fetch>
+    )
+    const { getByText } = render(component)
+    expect(globalScope.fetch).not.toHaveBeenCalled()
+    fireEvent.click(getByText("run"))
+    expect(globalScope.fetch).toHaveBeenCalledWith(
+      "/bar",
+      expect.objectContaining({ signal: abortCtrl.signal })
+    )
+  })
+
+  test("overriding the `resource` can be combined with overriding `init`", () => {
+    const component = (
+      <Fetch input="/foo" init={{ method: "POST", body: '{"name":"foo"}' }}>
+        {({ run }) => (
+          <button onClick={() => run("/bar", init => ({ ...init, body: '{"name":"bar"}' }))}>
+            run
+          </button>
+        )}
+      </Fetch>
+    )
+    const { getByText } = render(component)
+    expect(globalScope.fetch).not.toHaveBeenCalled()
+    fireEvent.click(getByText("run"))
+    expect(globalScope.fetch).toHaveBeenCalledWith(
+      "/bar",
+      expect.objectContaining({ method: "POST", signal: abortCtrl.signal, body: '{"name":"bar"}' })
     )
   })
 


### PR DESCRIPTION
# Description

This fixes #111. Besides allowing the override of fetch's `init` param, this enables overriding of the `resource` param as well.

# Checklist

Make sure you check all the boxes. You can omit items that are not applicable.

- [x] Added / updated the unit tests
- [x] Added / updated the documentation
- [x] Updated the TypeScript type definitions
