### PR TITLE
Avoid extending built-in JS classes

### DIFF
--- a/packages/react-async/src/reducer.js
+++ b/packages/react-async/src/reducer.js
@@ -1,25 +1,23 @@
 import { getInitialStatus, getIdleStatus, getStatusProps, statusTypes } from "./status"
 
 // This exists to make sure we don't hold any references to user-provided functions
-class NeverSettle extends Promise {
-  constructor() {
-    super(() => {}, () => {})
-    /* istanbul ignore next */
-    if (Object.setPrototypeOf) {
-      // Not available in IE 10, but can be polyfilled
-      Object.setPrototypeOf(this, NeverSettle.prototype)
-    }
-  }
+function NeverSettle() {}
+/* istanbul ignore next */
+if (Object.setPrototypeOf) {
+  // Not available in IE 10, but can be polyfilled
+  Object.setPrototypeOf(NeverSettle, Promise)
+}
+NeverSettle.prototype = Object.assign(Object.create(Promise.prototype), {
   finally() {
     return this
-  }
+  },
   catch() {
     return this
-  }
+  },
   then() {
     return this
-  }
-}
+  },
+})
 
 export const neverSettle = new NeverSettle()
 


### PR DESCRIPTION
# Description

Babel [does not support](https://babeljs.io/docs/en/caveats/#classes) transpiling `X extends Builtin` for built-in JS classes to ES5. Therefore we must use a different solution for our custom `NeverSettle` and `FetchError` classes.

Fixes #174 
