### PR TITLE
Fix generix type declaration

### DIFF
--- a/packages/react-async/src/Async.tsx
+++ b/packages/react-async/src/Async.tsx
@@ -68,10 +68,10 @@ type AsyncConstructor<T> = React.ComponentClass<AsyncProps<T>> & {
  * createInstance allows you to create instances of Async that are bound to a specific promise.
  * A unique instance also uses its own React context for better nesting capability.
  */
-export const createInstance = <T extends {}>(
+export function createInstance<T>(
   defaultOptions: AsyncProps<T> = {},
   displayName = "Async"
-): AsyncConstructor<T> => {
+): AsyncConstructor<T> {
   const { Consumer: UnguardedConsumer, Provider } = React.createContext<AsyncState<T> | undefined>(
     undefined
   )

--- a/packages/react-async/src/useAsync.tsx
+++ b/packages/react-async/src/useAsync.tsx
@@ -38,13 +38,10 @@ export interface FetchOptions<T> extends AsyncOptions<T> {
   json?: boolean
 }
 
-function useAsync<T extends {}>(options: AsyncOptions<T>): AsyncState<T>
-function useAsync<T extends {}>(promiseFn: PromiseFn<T>, options?: AsyncOptions<T>): AsyncState<T>
+function useAsync<T>(options: AsyncOptions<T>): AsyncState<T>
+function useAsync<T>(promiseFn: PromiseFn<T>, options?: AsyncOptions<T>): AsyncState<T>
 
-function useAsync<T extends {}>(
-  arg1: AsyncOptions<T> | PromiseFn<T>,
-  arg2?: AsyncOptions<T>
-): AsyncState<T> {
+function useAsync<T>(arg1: AsyncOptions<T> | PromiseFn<T>, arg2?: AsyncOptions<T>): AsyncState<T> {
   const options: AsyncOptions<T> =
     typeof arg1 === "function"
       ? {
@@ -285,11 +282,11 @@ function isEvent(e: FetchRunArgs[0]): e is Event | React.SyntheticEvent {
  * @param {FetchOptions} options
  * @returns {AsyncState<T, FetchRun<T>>}
  */
-const useAsyncFetch = <T extends {}>(
+function useAsyncFetch<T>(
   resource: RequestInfo,
   init: RequestInit,
   { defer, json, ...options }: FetchOptions<T> = {}
-): AsyncState<T, FetchRun<T>> => {
+): AsyncState<T, FetchRun<T>> {
   const method = (resource as Request).method || (init && init.method)
   const headers: Headers & Record<string, any> =
     (resource as Request).headers || (init && init.headers) || {}


### PR DESCRIPTION
# Description

Closes #227. Iirc the `T extends {}` was just a quick fix for the problem TS has parsing generic arrow functions in JSX files. @phryneas do you agree?

## Breaking changes

None

# Checklist

- [x] Updated the TypeScript type definitions
