### PR TITLE
Export Props interfaces to allow exported declarations

### DIFF
--- a/packages/react-async/src/Async.tsx
+++ b/packages/react-async/src/Async.tsx
@@ -22,23 +22,23 @@ import {
   ReducerAsyncState,
 } from "./types"
 
-interface InitialProps<T> {
+export interface InitialProps<T> {
   children?: InitialChildren<T>
   persist?: boolean
 }
-interface PendingProps<T> {
+export interface PendingProps<T> {
   children?: PendingChildren<T>
   initial?: boolean
 }
-interface FulfilledProps<T> {
+export interface FulfilledProps<T> {
   children?: FulfilledChildren<T>
   persist?: boolean
 }
-interface RejectedProps<T> {
+export interface RejectedProps<T> {
   children?: RejectedChildren<T>
   persist?: boolean
 }
-interface SettledProps<T> {
+export interface SettledProps<T> {
   children?: SettledChildren<T>
   persist?: boolean
 }

--- a/packages/react-async/src/index.ts
+++ b/packages/react-async/src/index.ts
@@ -1,5 +1,5 @@
 import Async from "./Async"
-export { default as Async, createInstance } from "./Async"
+export { default as Async, createInstance, AsyncConstructor, FulfilledProps, InitialProps, PendingProps, RejectedProps, SettledProps } from "./Async"
 export * from "./types"
 export { default as useAsync, useFetch, FetchOptions, FetchError } from "./useAsync"
 export default Async

--- a/packages/react-async/src/index.ts
+++ b/packages/react-async/src/index.ts
@@ -1,5 +1,14 @@
 import Async from "./Async"
-export { default as Async, createInstance, AsyncConstructor, FulfilledProps, InitialProps, PendingProps, RejectedProps, SettledProps } from "./Async"
+export {
+  default as Async,
+  createInstance,
+  AsyncConstructor,
+  FulfilledProps,
+  InitialProps,
+  PendingProps,
+  RejectedProps,
+  SettledProps,
+} from "./Async"
 export * from "./types"
 export { default as useAsync, useFetch, FetchOptions, FetchError } from "./useAsync"
 export default Async


### PR DESCRIPTION
Otherwise we get:

TS4023: Exported variable 'MyAsync' has or is using name 'PendingProps' from external module "<snip>/node_modules/react-async/dist-types/index" but cannot be named.

