### PR TITLE
Added an explicit browserlist for Parcel builds (IE 11 support)

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "author": "Gert Hengeveld <info@ghengeveld.nl>",
   "license": "ISC",
   "homepage": "https://async-library.com",
+  "browserslist": "last 2 Firefox versions",
   "repository": "git+https://github.com/async-library/react-async.git",
   "workspaces": [
     "examples/*",


### PR DESCRIPTION
Added a browserlist to indicate support for modern ES. When Parcel detects a library's browserlist is different then the application browser list it will transpile the library to the version of ES required by the application. This allows developers to specify older browsers (eg. ie 11) and have react-async transparently transpiled.

Edit: Without this Parcel assumes react-async is already compiled to ES5.