### PR TITLE
Added browserlist to nested package.jsons (missed these the first time)

### DIFF
--- a/packages/react-async-devtools/package.json
+++ b/packages/react-async-devtools/package.json
@@ -10,6 +10,7 @@
   "author": "Gert Hengeveld <info@ghengeveld.nl>",
   "license": "ISC",
   "homepage": "https://react-async.com/",
+  "browserslist": "last 2 Firefox versions",
   "repository": {
     "type": "git",
     "url": "https://github.com/async-library/react-async.git",

--- a/packages/react-async/package.json
+++ b/packages/react-async/package.json
@@ -12,6 +12,7 @@
   "author": "Gert Hengeveld <info@ghengeveld.nl>",
   "license": "ISC",
   "homepage": "https://react-async.com/",
+  "browserslist": "last 2 Firefox versions",
   "repository": {
     "type": "git",
     "url": "https://github.com/async-library/react-async.git",


### PR DESCRIPTION
This should fix parcel.js compatibility - my previous PR was mistakenly on the monorepo package.json as opposed to the sub packages where it should be. This fixes that mistake.